### PR TITLE
1.4.1 Nuevo atributo en DriverDocumentsStatus para indicar si una taxista

### DIFF
--- a/docs/enums/FirestoreCollections.md
+++ b/docs/enums/FirestoreCollections.md
@@ -30,7 +30,7 @@ Coleccion de [Administrator](../interfaces/Administrator.md)
 
 #### Defined in
 
-[index.ts:15](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L15)
+[index.ts:15](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L15)
 
 ___
 
@@ -42,7 +42,7 @@ Coleccion de [Customer](../interfaces/Customer.md)
 
 #### Defined in
 
-[index.ts:18](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L18)
+[index.ts:18](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L18)
 
 ___
 
@@ -54,7 +54,7 @@ Coleccion de [DriverAlert](../interfaces/DriverAlert.md)
 
 #### Defined in
 
-[index.ts:27](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L27)
+[index.ts:27](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L27)
 
 ___
 
@@ -66,7 +66,7 @@ Coleccion de [DriverDocuments](../interfaces/DriverDocuments.md)
 
 #### Defined in
 
-[index.ts:30](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L30)
+[index.ts:30](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L30)
 
 ___
 
@@ -78,7 +78,7 @@ Coleccion de [DriverDocumentsStatus](../interfaces/DriverDocumentsStatus.md)
 
 #### Defined in
 
-[index.ts:33](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L33)
+[index.ts:33](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L33)
 
 ___
 
@@ -90,7 +90,7 @@ Coleccion de [DriverLocation](../interfaces/DriverLocation.md)
 
 #### Defined in
 
-[index.ts:24](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L24)
+[index.ts:24](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L24)
 
 ___
 
@@ -102,7 +102,7 @@ Coleccion de [DriverStatus](../interfaces/DriverStatus.md)
 
 #### Defined in
 
-[index.ts:36](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L36)
+[index.ts:36](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L36)
 
 ___
 
@@ -114,7 +114,7 @@ Coleccion de [Driver](../interfaces/Driver.md)
 
 #### Defined in
 
-[index.ts:21](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L21)
+[index.ts:21](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L21)
 
 ___
 
@@ -126,7 +126,7 @@ Coleccion de [FavoriteLocation](../interfaces/FavoriteLocation.md)
 
 #### Defined in
 
-[index.ts:39](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L39)
+[index.ts:39](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L39)
 
 ___
 
@@ -138,7 +138,7 @@ Coleccion de [OrganizationSetting](../interfaces/OrganizationSetting.md)
 
 #### Defined in
 
-[index.ts:42](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L42)
+[index.ts:42](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L42)
 
 ___
 
@@ -150,7 +150,7 @@ Coleccion de [PanicModeAlert](../interfaces/PanicModeAlert.md)
 
 #### Defined in
 
-[index.ts:45](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L45)
+[index.ts:45](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L45)
 
 ___
 
@@ -162,7 +162,7 @@ Coleccion de [Review](../interfaces/Review.md)
 
 #### Defined in
 
-[index.ts:51](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L51)
+[index.ts:51](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L51)
 
 ___
 
@@ -174,4 +174,4 @@ Coleccion de [Trip](../interfaces/Trip.md)
 
 #### Defined in
 
-[index.ts:48](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/index.ts#L48)
+[index.ts:48](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/index.ts#L48)

--- a/docs/interfaces/Administrator.md
+++ b/docs/interfaces/Administrator.md
@@ -20,7 +20,7 @@ Representa un usuario administrador del sistema (la controladora)
 
 #### Defined in
 
-[src/admin/index.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L7)
+[src/admin/index.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L7)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L8)
+[src/admin/index.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L8)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L9)
+[src/admin/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L9)

--- a/docs/interfaces/Customer.md
+++ b/docs/interfaces/Customer.md
@@ -27,7 +27,7 @@ id generado por el modulo de Autenticacion de Firebase
 
 #### Defined in
 
-[src/customer/index.ts:17](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L17)
+[src/customer/index.ts:17](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L17)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L11)
+[src/customer/index.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L11)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L8)
+[src/customer/index.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L8)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L9)
+[src/customer/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L9)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:13](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L13)
+[src/customer/index.ts:13](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L13)
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L10)
+[src/customer/index.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L10)
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:14](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L14)
+[src/customer/index.ts:14](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L14)
 
 ___
 
@@ -99,7 +99,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:18](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L18)
+[src/customer/index.ts:18](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L18)
 
 ___
 
@@ -111,4 +111,4 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:16](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L16)
+[src/customer/index.ts:16](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L16)

--- a/docs/interfaces/Driver.md
+++ b/docs/interfaces/Driver.md
@@ -25,7 +25,7 @@ Usuaria Taxista
 
 #### Defined in
 
-[src/driver/index.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L8)
+[src/driver/index.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L8)
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L9)
+[src/driver/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L9)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L7)
+[src/driver/index.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L7)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L10)
+[src/driver/index.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L10)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L11)
+[src/driver/index.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L11)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:12](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L12)
+[src/driver/index.ts:12](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L12)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:14](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L14)
+[src/driver/index.ts:14](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L14)
 
 ___
 
@@ -95,4 +95,4 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:13](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L13)
+[src/driver/index.ts:13](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L13)

--- a/docs/interfaces/DriverAlert.md
+++ b/docs/interfaces/DriverAlert.md
@@ -22,7 +22,7 @@ Alertas de taxistas, SIN modo panico
 
 #### Defined in
 
-[src/admin/index.ts:20](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L20)
+[src/admin/index.ts:20](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L20)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:19](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L19)
+[src/admin/index.ts:19](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L19)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:21](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L21)
+[src/admin/index.ts:21](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L21)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:17](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L17)
+[src/admin/index.ts:17](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L17)
 
 ___
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:18](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L18)
+[src/admin/index.ts:18](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L18)

--- a/docs/interfaces/DriverDocuments.md
+++ b/docs/interfaces/DriverDocuments.md
@@ -38,7 +38,7 @@ en [Driver](Driver.md)
 
 #### Defined in
 
-[src/driver/index.ts:74](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L74)
+[src/driver/index.ts:74](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L74)
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:71](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L71)
+[src/driver/index.ts:71](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L71)
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:72](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L72)
+[src/driver/index.ts:72](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L72)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:69](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L69)
+[src/driver/index.ts:69](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L69)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:68](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L68)
+[src/driver/index.ts:68](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L68)
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:73](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L73)
+[src/driver/index.ts:73](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L73)
 
 ___
 
@@ -98,7 +98,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:56](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L56)
+[src/driver/index.ts:56](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L56)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:70](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L70)
+[src/driver/index.ts:70](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L70)
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:58](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L58)
+[src/driver/index.ts:58](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L58)
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:57](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L57)
+[src/driver/index.ts:57](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L57)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:63](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L63)
+[src/driver/index.ts:63](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L63)
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:62](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L62)
+[src/driver/index.ts:62](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L62)
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:59](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L59)
+[src/driver/index.ts:59](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L59)
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:61](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L61)
+[src/driver/index.ts:61](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L61)
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:60](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L60)
+[src/driver/index.ts:60](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L60)
 
 ___
 
@@ -188,7 +188,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:67](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L67)
+[src/driver/index.ts:67](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L67)
 
 ___
 
@@ -198,7 +198,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:66](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L66)
+[src/driver/index.ts:66](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L66)
 
 ___
 
@@ -208,7 +208,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:65](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L65)
+[src/driver/index.ts:65](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L65)
 
 ___
 
@@ -218,4 +218,4 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:64](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L64)
+[src/driver/index.ts:64](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L64)

--- a/docs/interfaces/DriverDocumentsStatus.md
+++ b/docs/interfaces/DriverDocumentsStatus.md
@@ -18,6 +18,7 @@ en [Driver](Driver.md)
 - [carPermit](DriverDocumentsStatus.md#carpermit)
 - [carRightView](DriverDocumentsStatus.md#carrightview)
 - [criminalRecord](DriverDocumentsStatus.md#criminalrecord)
+- [documentsAboutToExpire](DriverDocumentsStatus.md#documentsabouttoexpire)
 - [id](DriverDocumentsStatus.md#id)
 - [insurance](DriverDocumentsStatus.md#insurance)
 - [license](DriverDocumentsStatus.md#license)
@@ -32,7 +33,7 @@ en [Driver](Driver.md)
 
 #### Defined in
 
-[src/driver/index.ts:90](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L90)
+[src/driver/index.ts:91](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L91)
 
 ___
 
@@ -42,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:95](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L95)
+[src/driver/index.ts:96](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L96)
 
 ___
 
@@ -52,7 +53,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:92](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L92)
+[src/driver/index.ts:93](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L93)
 
 ___
 
@@ -62,7 +63,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:93](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L93)
+[src/driver/index.ts:94](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L94)
 
 ___
 
@@ -72,7 +73,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:91](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L91)
+[src/driver/index.ts:92](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L92)
 
 ___
 
@@ -82,7 +83,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:94](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L94)
+[src/driver/index.ts:95](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L95)
 
 ___
 
@@ -92,7 +93,17 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:89](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L89)
+[src/driver/index.ts:90](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L90)
+
+___
+
+### documentsAboutToExpire
+
+• **documentsAboutToExpire**: `boolean`
+
+#### Defined in
+
+[src/driver/index.ts:84](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L84)
 
 ___
 
@@ -102,7 +113,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:84](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L84)
+[src/driver/index.ts:85](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L85)
 
 ___
 
@@ -112,7 +123,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:85](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L85)
+[src/driver/index.ts:86](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L86)
 
 ___
 
@@ -122,7 +133,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:87](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L87)
+[src/driver/index.ts:88](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L88)
 
 ___
 
@@ -132,7 +143,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:88](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L88)
+[src/driver/index.ts:89](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L89)
 
 ___
 
@@ -142,4 +153,4 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:86](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L86)
+[src/driver/index.ts:87](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L87)

--- a/docs/interfaces/DriverLocation.md
+++ b/docs/interfaces/DriverLocation.md
@@ -21,7 +21,7 @@ al igual que la fecha donde se actualizó, usando coordenadas.
 
 #### Defined in
 
-[src/driver/index.ts:23](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L23)
+[src/driver/index.ts:23](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L23)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:22](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L22)
+[src/driver/index.ts:22](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L22)
 
 ___
 
@@ -41,4 +41,4 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:24](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L24)
+[src/driver/index.ts:24](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L24)

--- a/docs/interfaces/DriverStatus.md
+++ b/docs/interfaces/DriverStatus.md
@@ -24,7 +24,7 @@ Status de la usuaria taxista
 
 #### Defined in
 
-[src/driver/index.ts:41](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L41)
+[src/driver/index.ts:41](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L41)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:46](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L46)
+[src/driver/index.ts:46](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L46)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:45](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L45)
+[src/driver/index.ts:45](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L45)
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:44](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L44)
+[src/driver/index.ts:44](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L44)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:40](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L40)
+[src/driver/index.ts:40](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L40)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:47](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L47)
+[src/driver/index.ts:47](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L47)
 
 ___
 
@@ -86,4 +86,4 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:42](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L42)
+[src/driver/index.ts:42](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L42)

--- a/docs/interfaces/FavoriteLocation.md
+++ b/docs/interfaces/FavoriteLocation.md
@@ -23,7 +23,7 @@ Document Id del [Customer](Customer.md) a quien pertenece este lugar favorito
 
 #### Defined in
 
-[src/customer/index.ts:26](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L26)
+[src/customer/index.ts:26](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L26)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:29](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L29)
+[src/customer/index.ts:29](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L29)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:28](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L28)
+[src/customer/index.ts:28](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L28)
 
 ___
 
@@ -53,4 +53,4 @@ ___
 
 #### Defined in
 
-[src/customer/index.ts:27](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/customer/index.ts#L27)
+[src/customer/index.ts:27](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/customer/index.ts#L27)

--- a/docs/interfaces/OrganizationSetting.md
+++ b/docs/interfaces/OrganizationSetting.md
@@ -21,7 +21,7 @@ Opciones de configuracion del sistema
 
 #### Defined in
 
-[src/other/organization-setting.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/organization-setting.ts#L7)
+[src/other/organization-setting.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/organization-setting.ts#L7)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[src/other/organization-setting.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/organization-setting.ts#L8)
+[src/other/organization-setting.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/organization-setting.ts#L8)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[src/other/organization-setting.ts:5](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/organization-setting.ts#L5)
+[src/other/organization-setting.ts:5](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/organization-setting.ts#L5)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[src/other/organization-setting.ts:6](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/organization-setting.ts#L6)
+[src/other/organization-setting.ts:6](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/organization-setting.ts#L6)

--- a/docs/interfaces/PanicModeAlert.md
+++ b/docs/interfaces/PanicModeAlert.md
@@ -24,7 +24,7 @@ Alertas de Modo Panico activado
 
 #### Defined in
 
-[src/admin/index.ts:33](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L33)
+[src/admin/index.ts:33](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L33)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:29](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L29)
+[src/admin/index.ts:29](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L29)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:30](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L30)
+[src/admin/index.ts:30](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L30)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:35](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L35)
+[src/admin/index.ts:35](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L35)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:34](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L34)
+[src/admin/index.ts:34](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L34)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:28](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L28)
+[src/admin/index.ts:28](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L28)
 
 ___
 
@@ -86,4 +86,4 @@ ___
 
 #### Defined in
 
-[src/admin/index.ts:32](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/admin/index.ts#L32)
+[src/admin/index.ts:32](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/admin/index.ts#L32)

--- a/docs/interfaces/Review.md
+++ b/docs/interfaces/Review.md
@@ -23,7 +23,7 @@ Review de usuaria a taxista o de taxista a usuaria
 
 #### Defined in
 
-[src/other/review.ts:12](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/review.ts#L12)
+[src/other/review.ts:12](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/review.ts#L12)
 
 ___
 
@@ -35,7 +35,7 @@ Document Id del [Customer](Customer.md) asociado a este review
 
 #### Defined in
 
-[src/other/review.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/review.ts#L10)
+[src/other/review.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/review.ts#L10)
 
 ___
 
@@ -47,7 +47,7 @@ Document Id del [Driver](Driver.md) asociado a este review
 
 #### Defined in
 
-[src/other/review.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/review.ts#L8)
+[src/other/review.ts:8](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/review.ts#L8)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[src/other/review.ts:13](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/review.ts#L13)
+[src/other/review.ts:13](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/review.ts#L13)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[src/other/review.ts:15](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/review.ts#L15)
+[src/other/review.ts:15](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/review.ts#L15)
 
 ___
 
@@ -79,4 +79,4 @@ ___
 
 #### Defined in
 
-[src/other/review.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/review.ts#L11)
+[src/other/review.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/review.ts#L11)

--- a/docs/interfaces/Trip.md
+++ b/docs/interfaces/Trip.md
@@ -29,7 +29,7 @@ Document Id del [Customer](Customer.md)
 
 #### Defined in
 
-[src/trip/index.ts:22](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L22)
+[src/trip/index.ts:22](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L22)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:30](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L30)
+[src/trip/index.ts:30](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L30)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:31](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L31)
+[src/trip/index.ts:31](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L31)
 
 ___
 
@@ -61,7 +61,7 @@ Document Id del [Driver](Driver.md)
 
 #### Defined in
 
-[src/trip/index.ts:24](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L24)
+[src/trip/index.ts:24](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L24)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:26](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L26)
+[src/trip/index.ts:26](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L26)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:34](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L34)
+[src/trip/index.ts:34](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L34)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:33](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L33)
+[src/trip/index.ts:33](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L33)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:29](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L29)
+[src/trip/index.ts:29](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L29)
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:28](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L28)
+[src/trip/index.ts:28](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L28)
 
 ___
 
@@ -129,4 +129,4 @@ Id del viaje (4 o 5 digitos, para facilidad para las usuarias)
 
 #### Defined in
 
-[src/trip/index.ts:20](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L20)
+[src/trip/index.ts:20](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L20)

--- a/docs/interfaces/TripLocation.md
+++ b/docs/interfaces/TripLocation.md
@@ -23,7 +23,7 @@ tiene su propia coleccion
 
 #### Defined in
 
-[src/trip/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L9)
+[src/trip/index.ts:9](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L9)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:12](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L12)
+[src/trip/index.ts:12](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L12)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L11)
+[src/trip/index.ts:11](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L11)
 
 ___
 
@@ -53,4 +53,4 @@ ___
 
 #### Defined in
 
-[src/trip/index.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/trip/index.ts#L10)
+[src/trip/index.ts:10](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/trip/index.ts#L10)

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[src/other/enums.ts:1](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/enums.ts#L1)
+[src/other/enums.ts:1](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/enums.ts#L1)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[src/other/enums.ts:3](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/enums.ts#L3)
+[src/other/enums.ts:3](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/enums.ts#L3)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[src/driver/index.ts:27](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/driver/index.ts#L27)
+[src/driver/index.ts:27](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/driver/index.ts#L27)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[src/other/enums.ts:5](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/enums.ts#L5)
+[src/other/enums.ts:5](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/enums.ts#L5)
 
 ___
 
@@ -81,4 +81,4 @@ ___
 
 #### Defined in
 
-[src/other/enums.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/0866c8c/src/other/enums.ts#L7)
+[src/other/enums.ts:7](https://github.com/gatitolabs/kane-dbtypes/blob/73714e6/src/other/enums.ts#L7)

--- a/lib/src/driver/index.d.ts
+++ b/lib/src/driver/index.d.ts
@@ -1,4 +1,4 @@
-import { Trip } from "../trip";
+import { Trip } from '../trip';
 /**
  * Usuaria Taxista
  */
@@ -68,6 +68,7 @@ export interface DriverDocuments {
  * en {@link Driver}
  */
 export interface DriverDocumentsStatus {
+    documentsAboutToExpire: boolean;
     id: boolean;
     insurance: boolean;
     property: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kane-dbtypes",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Proyecto KANE: Documentos NoSQL para Firestore",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/driver/index.ts
+++ b/src/driver/index.ts
@@ -1,4 +1,4 @@
-import { Trip } from "../trip";
+import {Trip} from '../trip';
 
 /**
  * Usuaria Taxista
@@ -81,6 +81,7 @@ export interface DriverDocuments {
  * en {@link Driver}
  */
 export interface DriverDocumentsStatus {
+  documentsAboutToExpire: boolean;
   id: boolean;
   insurance: boolean;
   property: boolean;


### PR DESCRIPTION
1.4.1 Nuevo atributo en DriverDocumentsStatus para indicar si una taxista tiene documentos prontos a vencer.

## ⚙️ Tarea

https://gatitolabs.atlassian.net/jira/software/c/projects/KT/boards/14?modal=detail&selectedIssue=KT-17

## 💬 Descripción

Se añade un campo en DriverDocumentsStatus para indicar si una taxista tiene documentos prontos a vencer, para poder manejarlo dentro de la aplicación de la taxista.

## 🔎 Alcance del cambio

- [X] 📝 Implementación de Historia de Usuario / Requerimiento
- [ ] 🐞 Arreglo de un error/bug
- [X] 🚨 Cambio no compatible hacia atrás (e.g. se cambió el contrato de un API, se eliminó una pantalla, etc)
- [ ] ⚒️ Otro (indicar aquí)

## ✅ Lista de Chequeo

Seleccionar todas las opciones que apliquen

- [ ] Pruebas de Unidad Actualizadas
- [X] Coordinación con otros grupos lista
